### PR TITLE
Cast getLimit() result to int instead of string

### DIFF
--- a/src/Parameters.php
+++ b/src/Parameters.php
@@ -112,7 +112,15 @@ class Parameters
      */
     public function getLimit($max = null)
     {
-        $limit = $this->getPage('limit') ?: $this->getPage('size') ?: null;
+        $limit = (int) $this->getPage('limit');
+
+        if (!$limit) {
+            $limit = (int) $this->getPage('size');
+        }
+
+        if (!$limit) {
+            $limit = null;
+        }
 
         if ($limit && $max) {
             $limit = min($max, $limit);


### PR DESCRIPTION
Currently method getLimit() returns string, which is different from PHPDoc.
It could affect PHP apps which used declare(strict_types=1);